### PR TITLE
Adding Config option and Closing menu when clicked out of menu

### DIFF
--- a/css/px-deck-selector.css
+++ b/css/px-deck-selector.css
@@ -1152,6 +1152,9 @@ a {
   border-color: #b1b1bc;
   background-color: #f7f7fc;
   z-index: 99; }
+  .dropdown-menu li.deck-editor{
+    border-top: 1px solid #CCCCCC;
+    padding-top: 10px; }
   .dropdown-menu li div {
     color: #3b3b3f; }
     .dropdown-menu li div:hover {

--- a/css/px-deck-selector.css
+++ b/css/px-deck-selector.css
@@ -1152,9 +1152,6 @@ a {
   border-color: #b1b1bc;
   background-color: #f7f7fc;
   z-index: 99; }
-  .dropdown-menu li.deck-editor{
-    border-top: 1px solid #CCCCCC;
-    padding-top: 10px; }
   .dropdown-menu li div {
     color: #3b3b3f; }
     .dropdown-menu li div:hover {

--- a/demo.html
+++ b/demo.html
@@ -23,6 +23,11 @@
 
             <br><br>
 
+            <div>Config Option to add or remove deck</>
+            <px-deck-selector id="withConfigOption" selected-deck-url="{{url}}" config-option="{{configOptions}}"></px-deck-selector>
+
+            <br><br>
+
             <div>No decks - deck selector is hidden</div>
             <px-deck-selector id="noDecks"></px-deck-selector>
 
@@ -41,11 +46,33 @@
                     {name: 'Third Deck', url: '/deck3'}
                 ]);
 
+              var selector1 = document.getElementById('withConfigOption');
+
+              selector1.set(
+
+                  'decks', [
+                    {name: 'First Deck', url: '/deck1'},
+                    {name: 'Second Deck', url: '/deck2'},
+                    {name: 'Third Deck', url: '/deck3'}
+                ]);
+
+              selector1.set(
+                'configOptions', {
+                  edit : true,
+                  actionType : "Add Dashboard",
+                  eventType : "addDashboard"
+                });
+
                 // add test event listener
                 selector.addEventListener('selected-deck-url-changed', function(e) {
                     console.log(e.detail.value);
                 });
-                
+
+              // add test event listener
+                selector1.addEventListener('deckEvent', function(e) {
+                    console.log(e.detail);
+                });
+
             });
 
         </script>

--- a/px-deck-selector.html
+++ b/px-deck-selector.html
@@ -23,6 +23,11 @@ Element which displays a dropdown of decks and returns the url for the selected 
                     <div>{{deck.name}}</div>
                 </li>
             </template>
+            <template is="dom-if" if="{{configOptions.edit}}">
+                <li on-click="_triggerDeckEvent" class="deck-editor">
+                  <div>{{configOptions.actionType}}</div>
+                </li>
+            </template>
         </ul>
     </template>
 </dom-module>
@@ -80,7 +85,15 @@ Element which displays a dropdown of decks and returns the url for the selected 
              isDropdownOpen: {
                 type: Boolean,
                 value: false
-             }
+             },
+
+            /*
+            * Config option
+            * */
+            configOptions: {
+              value: null,
+              notify: true
+            }
         },
 
         _setDecks: function() {
@@ -95,14 +108,59 @@ Element which displays a dropdown of decks and returns the url for the selected 
             this.set('selectedDeck', selectedDeck);
         },
 
-        _toggleDropdown: function() {
+        _toggleDropdown: function(e) {
+
             this.isDropdownOpen = !this.isDropdownOpen;
             this.toggleAttribute('hidden', !this.isDropdownOpen, this.$.dropdown);
+            /*
+            * adding event listener to the document when menu is opened
+            * */
+            if(e){
+                this._handleDocumentClick();
+            }
         },
 
         _selectDeck: function(e) {
-            this.set('selectedDeck', e.model.deck);
-            this._toggleDropdown();
+          this.set('selectedDeck', e.model.deck);
+          this._toggleDropdown(false);
+        },
+
+        /*
+        *  this will allow to take care of adding or removing deck
+        *  which needs to be handled from the host component
+        * */
+        _triggerDeckEvent: function(e){
+          this.fire('deckEvent', e.model.configOptions.eventType );
+          this._toggleDropdown(false);
+        },
+
+        /*
+        * only called when the when clicked outside of menu
+        * */
+        _closeMenu: function(e, el){
+          if (!el.contains(e.target)) {
+            this.isDropdownOpen = false;
+            el.setAttribute('hidden', true);
+            document.removeEventListener('mouseup', this.evtHandler, false);
+          }
+        },
+
+        /*
+        * Adding and removing event listener on the document
+        * */
+         _handleDocumentClick : function(){
+
+           var el = this.$.dropdown;
+           var self = this;
+
+           if (!el.hasAttribute('hidden')) {
+            document.addEventListener('mouseup', self.evtHandler = function(e){self._closeMenu(e, el)}, false);
+            //document.ddMenu = this;
+          }
+          else {
+            document.removeEventListener('mouseup', self.evtHandler, false);
+            //document.ddMenu = null;
+          }
         }
     });
 </script>

--- a/sass/px-deck-selector-predix.scss
+++ b/sass/px-deck-selector-predix.scss
@@ -35,4 +35,8 @@ common/abstract rules go in px-deck-selector-sketch.scss, not in this file.
       background-color: $primary-blue;
     }
   }
+  li.deck-editor{
+    border-top: 1px solid #CCCCCC;
+    padding-top: 10px;
+  }
 }


### PR DESCRIPTION
Added features are:

Option to configure deck-selector by allowing them to add custom link which with fire custom event when clicked. Host element or other element will listen to custom event to modify(delete or add) deck.

Closing of the menu. Currently there when menu is opened and user click on other element outside of the menu, this menu will remains option. With update code, menu will be closed when clicking on other element outside of the menu